### PR TITLE
Fixed Slack's redirect URL

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,7 +11,7 @@ window.webslack = (function (gui, urllib, pkg, localStorage) {
 
 	var win = gui.Window.get();
 	var validSlackSubdomain = /(.+)\.slack.com/i;
-	var validSlackRedirect = /(.+\.)?slack-redir.com/i;
+	var validSlackRedirect = /(.+\.)?slack-redir.net/i;
 
 	win.on('new-win-policy', function (frame, url, policy) {
 		var openRequest = urllib.parse(url);


### PR DESCRIPTION
Slack has moved from `slack-redir.com` to `slack-redir.net` for all of their redirect URLs. This PR updates our code to match that change. Fixes #17.

In this PR:

- Moved `validSlackRedirect` from `.com` to `.net`

![selection_106](https://cloud.githubusercontent.com/assets/902488/6543928/041b002c-c4fa-11e4-9655-3ae650129cf3.png)

/cc @wlaurance 