### PR TITLE
Fix download interaction. Fixes #25

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,16 +11,27 @@
 
 	var win = gui.Window.get();
 	var validSlackSubdomain = /(.+)\.slack.com/i;
-	var validSlackRedirect = /(.+\.)?slack-redir.net/i;
+	var slackDownloadHostname = 'files.slack.com';
 
 	win.on('new-win-policy', function (frame, urlStr, policy) {
+		// Determine where the request is to
 		var openRequest = url.parse(urlStr);
 
-		if (validSlackRedirect.test(openRequest.host)) {
-			gui.Shell.openExternal(urlStr);
-			policy.ignore();
-			console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
+		// If the request is for a file, download it
+		// DEV: Files can be found on `files.slack.com`
+		//   https://files.slack.com/files-pri/{{id}}/download/tmp.txt
+		if (openRequest.hostname === slackDownloadHostname) {
+			policy.forceDownload();
+			console.log('Downloading file: ', urlStr);
+			return;
 		}
+
+		// Otherwise, open the window via our browser
+		// DEV: An example request is a redirect
+		//   https://slack-redir.net/link?url=http%3A%2F%2Fgoogle.com%2F
+		gui.Shell.openExternal(urlStr);
+		policy.ignore();
+		console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 	});
 
 	function newLocationToProcess(locationToProcess) {
@@ -40,7 +51,7 @@
 		}
 	}
 
-	function handleLoadIframe(url) {
+	function handleLoadIframe(urlStr) {
 		var bodyElement = document.body;
 
 		// Remove all the body's children nodes
@@ -50,7 +61,7 @@
 
 		var iframeDomElement = document.createElement('iframe');
 
-		iframeDomElement.setAttribute('src', url);
+		iframeDomElement.setAttribute('src', urlStr);
 		iframeDomElement.setAttribute('frameBorder', '0');
 		iframeDomElement.setAttribute('nwdisable', '');
 		iframeDomElement.setAttribute('nwfaketop', '');


### PR DESCRIPTION
In #25, we found that downloads are currently breaking the app. Once a download completes, the user is left on a white screen with no way to recover. This issue is being caused by too conservative of a `new-win-policy`.

This PR remedies that by detecting any requests for downloads (i.e. ones to `files.slack.com`) and opening a download prompt. Then, it will open any other new windows in the browser by default.

In this PR:

- Updated from conservative `new-win-policy` to catch-all case

![selection_115](https://cloud.githubusercontent.com/assets/902488/6958276/00b4b0de-d8cf-11e4-937f-13dee17753cf.png)

/cc @wlaurance 