### PR TITLE
Added multi team support. Fixes #21

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
     "node": true,
-    "esnext": true,
+    "browser": true,
     "bitwise": true,
     "camelcase": true,
     "curly": true,

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,8 +1,61 @@
-html, body, iframe {
+html, body {
 	width: 100%;
 	height: 100%;
 	padding: 0;
 	margin: 0;
 	border: none;
 	overflow: hidden;
+}
+
+body {
+	display: flex;
+}
+
+.hidden {
+	display: none;
+}
+
+.team-select {
+	background: #362533;
+	color: white;
+	/* Width is 44px + 1rem padding */
+	flex-basis: 76px;
+	min-width: 76px;
+	order: -1;
+	text-align: center;
+}
+
+.team-select a {
+	color: inherit;
+}
+
+.team-select__item {
+	list-style: none;
+}
+
+.team-select__item img {
+	/* http://viewsource.in/https://slack.global.ssl.fastly.net/c239/style/rollup-client_secondary.css#L1070 */
+	border-radius: 0.2rem;
+
+	/* Scale down to be same size as user icons */
+	height: 36px;
+	width: auto;
+}
+
+.team-select__item--active::before {
+	display: block;
+	position: absolute;
+	content: '\A0';
+	background: white;
+
+	width: 4px;
+	/* Same as icon */
+	height: 36px;
+
+	/* Use same border radius as icon for good measure*/
+	border-radius: 0 0.2rem 0.2rem 0;
+}
+
+.slack-window--active {
+	flex-grow: 1;
 }

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -1,9 +1,9 @@
-/* global document */
-/* global localStorage */
-/* global window */
-/* exported webslack */
-window.webslack = (function (gui, urllib, pkg, localStorage) {
+(function () {
 	'use strict';
+	var gui = require('nw.gui');
+	var url = require('url');
+	var pkg = require('../package.json');
+
 	var LOCAL_STORAGE_KEY_CURRENT_DOMAIN = 'currentDomain';
 	var SLACK_DOMAIN = 'slack.com';
 	var SLACK_LOGIN_URL = 'https://slack.com/signin';
@@ -13,18 +13,18 @@ window.webslack = (function (gui, urllib, pkg, localStorage) {
 	var validSlackSubdomain = /(.+)\.slack.com/i;
 	var validSlackRedirect = /(.+\.)?slack-redir.net/i;
 
-	win.on('new-win-policy', function (frame, url, policy) {
-		var openRequest = urllib.parse(url);
+	win.on('new-win-policy', function (frame, urlStr, policy) {
+		var openRequest = url.parse(urlStr);
 
 		if (validSlackRedirect.test(openRequest.host)) {
-			gui.Shell.openExternal(url);
+			gui.Shell.openExternal(urlStr);
 			policy.ignore();
 			console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 		}
 	});
 
 	function newLocationToProcess(locationToProcess) {
-		var locationHostname = urllib.parse(locationToProcess).hostname;
+		var locationHostname = url.parse(locationToProcess).hostname;
 
 		if (validSlackSubdomain.test(locationHostname)) {
 			var subdomain = validSlackSubdomain.exec(locationHostname);
@@ -107,5 +107,6 @@ window.webslack = (function (gui, urllib, pkg, localStorage) {
 		}
 	}));
 	tray.menu = trayMenu;
-	return webslack;
-})(require('nw.gui'), require('url'), require('../package.json'), localStorage);
+
+	window.webslack = webslack;
+})();

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -2,6 +2,7 @@
 	'use strict';
 	var gui = require('nw.gui');
 	var url = require('url');
+	var SlackWindow = require('../js/slack-window.js');
 	var pkg = require('../package.json');
 
 	var LOCAL_STORAGE_KEY_CURRENT_DOMAIN = 'currentDomain';
@@ -22,55 +23,6 @@
 			console.log('Allowing browser to handle: ' + JSON.stringify(openRequest));
 		}
 	});
-
-	function newLocationToProcess(locationToProcess) {
-		var locationHostname = url.parse(locationToProcess).hostname;
-
-		if (validSlackSubdomain.test(locationHostname)) {
-			var subdomain = validSlackSubdomain.exec(locationHostname);
-			if (subdomain[1] && subdomain[1].length > 1) {
-				var subdomainFiltered = subdomain[1];
-
-				if (subdomainFiltered !== localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN)) {
-					localStorage.setItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN, subdomainFiltered);
-				}
-			}
-		} else if (locationHostname === SLACK_DOMAIN) {
-			localStorage.removeItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN);
-		}
-	}
-
-	function handleLoadIframe(url) {
-		var bodyElement = document.body;
-
-		// Remove all the body's children nodes
-		while (bodyElement.firstChild) {
-			bodyElement.removeChild(bodyElement.firstChild);
-		}
-
-		var iframeDomElement = document.createElement('iframe');
-
-		iframeDomElement.setAttribute('src', url);
-		iframeDomElement.setAttribute('frameBorder', '0');
-		iframeDomElement.setAttribute('nwdisable', '');
-		iframeDomElement.setAttribute('nwfaketop', '');
-
-		bodyElement.appendChild(iframeDomElement);
-	}
-
-	win.on('document-start', function (frame) {
-		if (frame && frame.contentWindow) {
-			newLocationToProcess(frame.contentWindow.location.href);
-		}
-	});
-
-	webslack.load = function () {
-		if (localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN)) {
-			handleLoadIframe('https://' + localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN) + '.slack.com/');
-		} else {
-			handleLoadIframe(SLACK_LOGIN_URL);
-		}
-	};
 
 	var isMinimized = false;
 	win.on('minimize', function () {
@@ -107,6 +59,165 @@
 		}
 	}));
 	tray.menu = trayMenu;
+
+	function createSlackIframe(url) {
+		var iframe = document.createElement('iframe');
+		if (url) {
+			iframe.setAttribute('src', url);
+		}
+		iframe.setAttribute('frameBorder', '0');
+		iframe.setAttribute('nwdisable', '');
+		iframe.setAttribute('nwfaketop', '');
+		return iframe;
+	}
+
+	// On the initial page load
+	webslack.load = function () {
+		function newLocationToProcess(locationToProcess) {
+			var locationHostname = url.parse(locationToProcess).hostname;
+
+			if (validSlackSubdomain.test(locationHostname)) {
+				var subdomain = validSlackSubdomain.exec(locationHostname);
+				if (subdomain[1] && subdomain[1].length > 1) {
+					var subdomainFiltered = subdomain[1];
+
+					if (subdomainFiltered !== localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN)) {
+						localStorage.setItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN, subdomainFiltered);
+					}
+				}
+			} else if (locationHostname === SLACK_DOMAIN) {
+				localStorage.removeItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN);
+			}
+		}
+
+		// When a new page loads
+		win.on('document-start', function handlePageLoad (frame) {
+			// If the frame is our active frame, then process its location
+			if (frame && frame === activeWindow.iframe && frame.contentWindow) {
+				newLocationToProcess(frame.contentWindow.location.href);
+			}
+		});
+
+		// Open our last page
+		var openUrl = SLACK_LOGIN_URL;
+		if (localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN)) {
+			openUrl = 'https://' + localStorage.getItem(LOCAL_STORAGE_KEY_CURRENT_DOMAIN) + '.slack.com/';
+		}
+		var iframe = createSlackIframe(openUrl);
+		iframe.className = 'slack-window slack-window--active';
+
+		// Create a container for window interactions
+		var activeWindow = new SlackWindow(iframe);
+
+		// Render the window on the page
+		document.body.appendChild(iframe);
+
+		// When the window loads
+		activeWindow.on('chat-loaded', function handleLoad () {
+			// Gather team info
+			// team = {id:, name: "slack-for-linux test", email_domain: mailinator.com, domain: account name,
+			//   msg_edit_window_mins, prefs: {default_channels, ...},
+			//   icon: {image_34: http://url/34.png, image_{44,68,88,102,132}, image_default: true},
+			//   over_storage_limit, plan, url: wss://ms144.slack-msgs.com, activity}
+			var activeTeam = activeWindow.getTeam();
+			// DEV: Active team inside of `team` *does not* include `icon`
+			// teams = [{id: user id, name: user name, team_id, team_name: account name, team_name,
+			//   team_icon: {image_34: http://url/34.png, image_{44,68,88,102,132}, image_default: true},
+			//   team_url: https://subdomain.slack.com/}]
+			var teams = activeWindow.getAllTeams();
+
+			// Save our team to the window mapping
+			var teamWindows = {};
+			var teamListItems = {};
+			var teamIconMap = {};
+			teamWindows[activeTeam.id] = activeWindow;
+			teamIconMap[activeTeam.id] = activeTeam.icon;
+
+			// Create windows for other teams
+			teams.forEach(function generateWindow (team) {
+				// If there is a team window, continue
+				if (teamWindows[team.team_id]) {
+					return;
+				}
+
+				// Create/load the iframe
+				var iframe = createSlackIframe(team.team_url);
+				iframe.className = 'slack-window hidden';
+				document.body.appendChild(iframe);
+
+				// Save it to our team mapping
+				teamWindows[team.team_id] = new SlackWindow(iframe);
+				teamIconMap[team.team_id] = team.team_icon;
+			});
+
+			// Create a helper to mark activated link items
+			var activeListItem;
+			function markActiveListItem(listItem) {
+				// If the item is the active item, do nothing
+				if (listItem === activeListItem) {
+					return;
+				}
+
+				// Otherwise, adjust our flags
+				if (activeListItem) {
+					activeListItem.classList.remove('team-select__item--active');
+				}
+				listItem.classList.add('team-select__item--active');
+				activeListItem = listItem;
+			}
+
+			// Generate a sidebar for our teams
+			var sidebar = document.createElement('div');
+			var linkList = document.createElement('div');
+			sidebar.className = 'team-select';
+			teams.forEach(function addTeamIcon (team, i) {
+				// Create a link for the team
+				var linkListItem = document.createElement('p');
+				var teamLink = document.createElement('a');
+				linkListItem.className = 'team-select__item';
+				var teamImg = document.createElement('img');
+				var teamIcon = teamIconMap[team.team_id];
+				teamImg.src = teamIcon.image_44;
+				teamLink.href = '#';
+
+				// Resolve the team window
+				var teamWindow = teamWindows[team.team_id];
+
+				// When the link is clicked, swap active windows
+				teamLink.onclick = function () {
+					// If the new window is the current window, do nothing
+					if (activeWindow.iframe === teamWindow.iframe) {
+						return;
+					}
+
+					// Otherwise, update our frames
+					activeWindow.iframe.classList.remove('slack-window--active');
+					activeWindow.iframe.classList.add('hidden');
+					teamWindow.iframe.classList.add('slack-window--active');
+					teamWindow.iframe.classList.remove('hidden');
+					activeWindow = teamWindow;
+
+					// Update the link activity
+					markActiveListItem(linkListItem);
+				};
+				teamLink.appendChild(teamImg);
+				linkListItem.appendChild(teamLink);
+				linkList.appendChild(linkListItem);
+
+				// Save the list item by id
+				teamListItems[team.team_id] = linkListItem;
+			});
+
+			// Mark the active list item
+			markActiveListItem(teamListItems[activeTeam.id]);
+
+			// If we have more than 1 teams, bind to the DOM
+			sidebar.appendChild(linkList);
+			if (teams.length > 1) {
+				document.body.appendChild(sidebar);
+			}
+		});
+	};
 
 	window.webslack = webslack;
 })();

--- a/app/js/slack-window.js
+++ b/app/js/slack-window.js
@@ -1,0 +1,60 @@
+(function () {
+	'use strict';
+	var EventEmitter = require('events').EventEmitter;
+	var util = require('util');
+
+	function SlackWindow(iframe) {
+		// Inherit from EventEmitter
+		EventEmitter.call(this);
+
+		// Save iframe for later
+		this.iframe = iframe;
+
+		// When the page has loaded, fire a `chat-loaded` event
+		// DEV: This is to prevent ambiguity when loading "Team Choose" screen initially
+		// TODO: Verify this works when arriving at "Team Choose" screen on initial load
+		var that = this;
+		function loaded() {
+			that.emit('chat-loaded');
+		}
+
+		// If the page hasn't loaded yet, set up a listener
+		if (!this.hasLoaded()) {
+			// Wait for our page to partially load
+			iframe.onload = function () {
+				// Reset the onload handler to prevent multiple executions
+				iframe.onload = function () {};
+
+				// Wait for the page to completely load
+				function waitForLoaded() {
+					// If we haven't completed loading yet, wait for 100ms
+					if (!that.hasLoaded()) {
+						return setTimeout(waitForLoaded, 100);
+					}
+
+					// Otherwise, call our loaded handler
+					loaded();
+				}
+				waitForLoaded();
+			};
+		}
+	}
+	util.inherits(SlackWindow, EventEmitter);
+	SlackWindow.prototype.getTeam = function () {
+		var win = this.getWindow();
+		return win.TS.model.team;
+	};
+	SlackWindow.prototype.getAllTeams = function () {
+		var win = this.getWindow();
+		return win.TS.getAllTeams();
+	};
+	SlackWindow.prototype.getWindow = function () {
+		return this.iframe.contentWindow;
+	};
+	SlackWindow.prototype.hasLoaded = function () {
+		var win = this.getWindow();
+		return win &&  win.TS && win.TS.getAllTeams && win.TS.getAllTeams();
+	};
+
+	module.exports = SlackWindow;
+})();

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
   <script>
-    webslack.load();
+    window.webslack.load();
   </script>
 </body>
 </html>


### PR DESCRIPTION
**Depends on #23, please focus on HEAD commit**

This PR adds in a sidebar for when a user is logged into multiple teams. In this PR:

- Added CSS for sidebar
- Added sidebar logic to `index.js`
- Added `slack-window` abstraction for `iframe` handling
    - Lays groundwork for handling notifications on a per-team basis

**Notes:**

Currently, it is very naive and only runs at load time. I wanted to process when the user logs into other teams but then I was abstracting into a class and realized we should have a discussion. How do we want to handle complex sets of data and their updates (e.g. logging into multiple teams)? Do we want to roll our own thing or use a framework like React?

**Missing (should be new issues created):**

- Notifications badges on each team icon
    - Also, when #24 lands we will need to update that to handle multiple teams
- Shortcuts for each team icon
- Handling logging in/out of a team

/cc @wlaurance 