### PR TITLE
Added requirement for node>=0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-node-webkit-builder": "^1.0.0"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   },
   "os": [
     "linux"


### PR DESCRIPTION
In #28, we had a regression with installing against `node@0.9`. Many of our dependencies require `node@0.10` and so we should have the same requirement upfront. In this PR:

- Added requirement for `node>=0.10`

/cc @wlaurance 