### PR TITLE
Added plugin flag to enable Flash. Fixes #32

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,9 @@
     "min_height": 650,
     "toolbar": false
   },
+  "webkit": {
+    "plugin": true
+  },
   "chromium-args": "--child-clean-exit",
   "dependencies": {
     "get-uri": "^0.1.3",


### PR DESCRIPTION
In #32, we were informed that we could have YouTube previews inside of Slack. This was disabled due to Flash not being enabled. In this PR:

- Added plugin flag to enable Flash

**Before:**

![selection_119](https://cloud.githubusercontent.com/assets/902488/7083802/a111a872-df2b-11e4-9b35-1add98a7b312.png)

**After:**

![selection_118](https://cloud.githubusercontent.com/assets/902488/7083790/87a3ab38-df2b-11e4-9b41-7b1ccc4af01e.png)

/cc @wlaurance 