### PR TITLE
Change the app name

### DIFF
--- a/app/bower.json
+++ b/app/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "slack4linux",
+  "name": "slack-for-linux",
   "version": "0.0.1",
   "dependencies": {
     "favico.js": "^0.3.7"

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "slack4linux",
+  "name": "slack-for-linux",
   "main": "views/index.html",
   "version": "0.0.1",
   "single-instance": true,

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>slack4Linux</title>
+  <title>slack-for-linux</title>
   <link rel="stylesheet" href="../css/main.css" />
   <script src="../bower_components/favico.js/favico.js"></script>
   <script src="../js/index.js" ></script>

--- a/run.js
+++ b/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 var spawn = require('child_process').spawn;
 
-spawn(__dirname + '/./webkitbuilds/slack4linux/linux64/slack4linux');
+spawn(__dirname + '/./webkitbuilds/slack-for-linux/linux64/slack-for-linux');


### PR DESCRIPTION
There are some old references to 'slack4Linux' throughout the app.

At first, I changed all of the references. But this caused the app to lose the currently logged in teams.
