### PR TITLE
Add better install logging and fixed global nested npm install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
-# Exit upon the first error
+# Exit upon the first error and echo commands
 set -e
+set -x
+
+# Override our environment to consider all `npm` installs to be local
+npm_config_global=""
 
 # Install app's dependencies
 cd app/

--- a/run.js
+++ b/run.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Load in our dependencies
 var spawn = require('child_process').spawn;
 
-spawn(__dirname + '/./webkitbuilds/slack-for-linux/linux64/slack-for-linux');
+// Run our task and output stdout/stderr to parent
+spawn(__dirname + '/./webkitbuilds/slack-for-linux/linux64/slack-for-linux', {stdio: [0, 1, 2]});


### PR DESCRIPTION
We have received reports (and reproduced the issue) that global installation has broken (#43). This PR fixes #43 and adds output to help us debug future issues. In this PR:

- Added `set -x` to output what is occurring in `install.sh`
- Added `npm_config_global` override to force `npm install` inside of `install.sh` to be treated locally
    - Otherwise, we would be installing to `slack4linux`/`slack-for-linux` as another global application
- Added stdio forwarding to `run.js` in order to see error output from `nw` (e.g. failing to resolve dependencies)

/cc @wlaurance 