### PR TITLE
Moved to published build on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,6 @@ node_modules/
 tmp/
 .DS_Store
 
-webkitbuilds/
 cache/
+app/images/app-tray.png
+bower_components/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		nodewebkit: {
 			options: {
+				version: '0.12.1',
 				platforms: ['linux64'],
 				buildDir: './webkitbuilds' // Where the build version of my node-webkit app is saved
 			},

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git clone git@github.com:wlaurance/slack-for-linux.git && cd slack-for-linux
 ####Install deps
 
 ```
-npm install
+npm install && ./build.sh
 ```
 
 ####Run It

--- a/app/bower.json
+++ b/app/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "slack-for-linux",
-  "version": "0.0.1",
-  "dependencies": {
-    "favico.js": "^0.3.7"
-  }
-}

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
   },
   "chromium-args": "--child-clean-exit",
   "dependencies": {
+    "favico.js": "^0.3.8",
     "get-uri": "^0.1.3",
     "underscore": "^1.7.0"
   }

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -3,7 +3,8 @@
 <head>
   <title>slack-for-linux</title>
   <link rel="stylesheet" href="../css/main.css" />
-  <script src="../bower_components/favico.js/favico.js"></script>
+  <!-- DEV: favico.js is required to be loaded via `script` due to window properties like navigator not existing -->
+  <script src="../node_modules/favico.js/favico.js"></script>
   <script src="../js/index.js" ></script>
 </head>
 <body>

--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,14 @@
 set -e
 set -x
 
-# Override our environment to consider all `npm` installs to be local
-npm_config_global=""
+# Clean up our build folder
+if test -d webkitbuilds/; then
+  rm -r webkitbuilds/
+fi
 
 # Install app's dependencies
 cd app/
 npm install
-../node_modules/.bin/bower install
 cd ../
 
 # Build our application

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "url": "git://github.com/wlaurance/slack-for-linux"
   },
   "dependencies": {
-    "bower": "^1.3.12",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-node-webkit-builder": "^1.0.2"
@@ -31,15 +30,18 @@
     "linux"
   ],
   "scripts": {
-    "postinstall": "./install.sh",
+    "prepublish": "./build.sh",
     "test": "grunt lint"
   },
   "bin": {
     "slack-for-linux": "./run.js"
   },
   "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-jscs": "^1.1.0",
-    "grunt-lintspaces": "^0.6.0"
+    "grunt-lintspaces": "^0.6.0",
+    "grunt-node-webkit-builder": "^1.0.2"
   }
 }


### PR DESCRIPTION
**Depends on #50**

Since we introduced dependencies in `slack-for-linux`, we have been having permissioning issues due to building on machines. If we want to solve #13, we are going to need to move to a pre-built published model. This PR moves to that model by publishing the compiled version to `npm`.

In this PR:

- Renamed `install.sh` to `build.sh` (to denote that its for building)
- Removed `postinstall` hook for application
- Added `prepublish` hook for `build.sh` to guarantee fresh copy is published
- Updated documentation to include `build.sh`
- Updated `.npmignore` to publish `webkitbuilds/` folder

/cc @wlaurance 