### PR TITLE
Locked down nw.js version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		nodewebkit: {
 			options: {
+				version: '0.12.1',
 				platforms: ['linux64'],
 				buildDir: './webkitbuilds' // Where the build version of my node-webkit app is saved
 			},


### PR DESCRIPTION
This is a reopening of https://github.com/wlaurance/slack-for-linux/pull/49

-----------------------

While debugging #35, we had a version consistency issue. We need to lock down `nw.js` as though it were a dependency. In this PR:

- Locked down `nw.js` to latest stable version (0.12.1)

/cc @wlaurance 