### PR TITLE
Removed bower

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
 	grunt.initConfig({
 		nodewebkit: {
 			options: {
+				version: '0.12.1',
 				platforms: ['linux64'],
 				buildDir: './webkitbuilds' // Where the build version of my node-webkit app is saved
 			},

--- a/app/bower.json
+++ b/app/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "slack-for-linux",
-  "version": "0.0.1",
-  "dependencies": {
-    "favico.js": "^0.3.7"
-  }
-}

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
   },
   "chromium-args": "--child-clean-exit",
   "dependencies": {
+    "favico.js": "^0.3.8",
     "get-uri": "^0.1.3",
     "underscore": "^1.7.0"
   }

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -3,7 +3,8 @@
 <head>
   <title>slack-for-linux</title>
   <link rel="stylesheet" href="../css/main.css" />
-  <script src="../bower_components/favico.js/favico.js"></script>
+  <!-- DEV: favico.js is required to be loaded via `script` due to window properties like navigator not existing -->
+  <script src="../node_modules/favico.js/favico.js"></script>
   <script src="../js/index.js" ></script>
 </head>
 <body>

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,6 @@ npm_config_global=""
 # Install app's dependencies
 cd app/
 npm install
-../node_modules/.bin/bower install
 cd ../
 
 # Build our application

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "url": "git://github.com/wlaurance/slack-for-linux"
   },
   "dependencies": {
-    "bower": "^1.3.12",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-node-webkit-builder": "^1.0.2"


### PR DESCRIPTION
This is a reopening of #50 

----------------------

**Depends on #52**

In an attempt to reproduce #44, we installed `slack-for-linux` on a Vagrant box. One snag we ran into was `bower` choking when it had never been installed previously and running under root. In order to work around this (instead of requiring additional commands by our users as non-root), we are removing `bower`. In this PR:

- Removed `bower` as a dependency and `bower.json`
- Replaced `bower` with `npm`/`node_modules`

/cc @wlaurance 